### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The server is expected to respond with:
 ## Prerequisites
 
 Copy your mkcert root certificate to `rootCA.pem` in this directory so the app can verify the HTTPS connection.
-=======
 Ensure your mkcert root certificate is trusted by Node.js. You can do this by setting the `NODE_EXTRA_CA_CERTS` environment variable to the path of your mkcert root certificate (for example `rootCA.pem`).
 
 


### PR DESCRIPTION
## Summary
- remove stray separator line from README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686aa8549f648321ad3781c4f779d894